### PR TITLE
Fix integer overflows in AssemblyScript & Typescript implementations

### DIFF
--- a/assembly/Histogram.ts
+++ b/assembly/Histogram.ts
@@ -606,6 +606,13 @@ export default class Histogram<T, U> extends AbstractHistogramBase<T, U> {
 
   setCountAtIndex(index: i32, value: u64): void {
     // @ts-ignore
+    if ((<u64>value) as number > this.maxBucketSize) {
+      const bitSize = <u8>(sizeof<U>() * 8);
+      throw new Error(
+        value.toString() + " would overflow " + bitSize.toString() + "bits integer count"
+      );
+    }
+    // @ts-ignore
     unchecked((this.counts[index] = <U>value));
   }
 

--- a/assembly/Histogram.ts
+++ b/assembly/Histogram.ts
@@ -589,9 +589,11 @@ export default class Histogram<T, U> extends AbstractHistogramBase<T, U> {
     // @ts-ignore
     const currentCount = unchecked(this.counts[index]);
     const newCount = currentCount + 1;
-    if (newCount < 0) {
+    if (newCount < currentCount) {
+      const bitSize = <u8>(sizeof<U>() * 8);
+      const overflowAt = (<u64>currentCount + 1); 
       throw new Error(
-        newCount.toString() + " would overflow short integer count"
+        overflowAt.toString() + " would overflow " + bitSize.toString() + "bits integer count"
       );
     }
     // @ts-ignore

--- a/assembly/Histogram.ts
+++ b/assembly/Histogram.ts
@@ -49,6 +49,8 @@ export default class Histogram<T, U> extends AbstractHistogramBase<T, U> {
   counts: T;
   totalCount: u64 = 0;
 
+  maxBucketSize: number;
+
   constructor(
     lowestDiscernibleValue: u64,
     highestTrackableValue: u64,
@@ -119,6 +121,8 @@ export default class Histogram<T, U> extends AbstractHistogramBase<T, U> {
     this.establishSize(highestTrackableValue);
     // @ts-ignore
     this.counts = instantiate<T>(this.countsArrayLength);
+
+    this.maxBucketSize = 2 ** (sizeof<U>() * 8) - 1;
 
     this.leadingZeroCountBase =
       64 - this.unitMagnitude - this.subBucketHalfCountMagnitude - 1;
@@ -609,8 +613,12 @@ export default class Histogram<T, U> extends AbstractHistogramBase<T, U> {
     // @ts-ignore
     const currentCount = unchecked(this.counts[index]);
     const newCount = currentCount + value;
-    if (newCount < 0) {
-      throw newCount + " would overflow short integer count";
+    const u64NewCount = (<u64>currentCount + value) as number;
+    if (u64NewCount > this.maxBucketSize) {
+      const bitSize = <u8>(sizeof<U>() * 8);
+      throw new Error(
+        u64NewCount.toString() + " would overflow " + bitSize.toString() + "bits integer count"
+      );
     }
     // @ts-ignore
     unchecked((this.counts[index] = <U>newCount));

--- a/assembly/__tests__/Histogram.spec.ts
+++ b/assembly/__tests__/Histogram.spec.ts
@@ -326,9 +326,9 @@ describe("Histogram add & subtract", () => {
     const outputBefore = histogram.outputPercentileDistribution();
     // when
     histogram.add<Storage<Uint8Array, u8>, u8>(histogram2);
-    //histogram.subtract<Storage<Uint8Array, u8>, u8>(histogram2);
+    histogram.subtract<Storage<Uint8Array, u8>, u8>(histogram2);
     // then
-   //expect(histogram.outputPercentileDistribution()).toBe(outputBefore);
+    expect(histogram.outputPercentileDistribution()).toBe(outputBefore);
   });
 
   it("should be equal when another histogram of lower precision is added then subtracted", () => {

--- a/assembly/__tests__/Histogram.spec.ts
+++ b/assembly/__tests__/Histogram.spec.ts
@@ -317,18 +317,18 @@ describe("Histogram add & subtract", () => {
     // given
     const histogram = buildHistogram();
     const histogram2 = buildHistogram();
-    histogram.recordCountAtValue(2, 100);
-    histogram2.recordCountAtValue(1, 100);
-    histogram.recordCountAtValue(2, 200);
-    histogram2.recordCountAtValue(1, 200);
-    histogram.recordCountAtValue(2, 300);
-    histogram2.recordCountAtValue(1, 300);
+    histogram.recordCountAtValue(2, 10);
+    histogram2.recordCountAtValue(1, 10);
+    histogram.recordCountAtValue(2, 20);
+    histogram2.recordCountAtValue(1, 20);
+    histogram.recordCountAtValue(2, 30);
+    histogram2.recordCountAtValue(1, 30);
     const outputBefore = histogram.outputPercentileDistribution();
     // when
     histogram.add<Storage<Uint8Array, u8>, u8>(histogram2);
-    histogram.subtract<Storage<Uint8Array, u8>, u8>(histogram2);
+    //histogram.subtract<Storage<Uint8Array, u8>, u8>(histogram2);
     // then
-    expect(histogram.outputPercentileDistribution()).toBe(outputBefore);
+   //expect(histogram.outputPercentileDistribution()).toBe(outputBefore);
   });
 
   it("should be equal when another histogram of lower precision is added then subtracted", () => {

--- a/assembly/encoding.ts
+++ b/assembly/encoding.ts
@@ -111,9 +111,9 @@ function fillCountsArrayFromSourceBuffer<T, U>(
   const endPosition = sourceBuffer.position + lengthInBytes;
   while (sourceBuffer.position < endPosition) {
     let zerosCount: i32 = 0;
-    let count = <i32>ZigZagEncoding.decode(sourceBuffer);
+    let count = <i64>ZigZagEncoding.decode(sourceBuffer);
     if (count < 0) {
-      zerosCount = -count;
+      zerosCount = <i32>-count;
       dstIndex += zerosCount; // No need to set zeros in array. Just skip them.
     } else {
       self.setCountAtIndex(dstIndex++, count);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hdr-histogram-js",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/TypedArrayHistogram.spec.ts
+++ b/src/TypedArrayHistogram.spec.ts
@@ -67,3 +67,26 @@ import Float64Histogram from "./Float64Histogram";
     });
   }
 );
+
+
+describe("Histogram bucket size overflow", () => {
+  [Int8Histogram, Int16Histogram].forEach(
+    (Histogram) => {
+      it("should fail when recording more than 'maxBucketSize' times the same value", () => {
+        //given
+        const histogram = new Histogram(1, Number.MAX_SAFE_INTEGER, 3);
+        
+        //when //then
+        try {
+          let i = 0;
+          for (i; i <= histogram.maxBucketSize; i++) {
+            histogram.recordValue(1); 
+          }
+          fail(`should have failed due to ${histogram._counts.BYTES_PER_ELEMENT * 8}bits integer overflow (bucket size: ${i})`);
+        } catch (e) {
+          //ok
+          expect(histogram.getCountAtIndex(1)).toBe(histogram.maxBucketSize);
+        }
+      });
+    })
+});

--- a/src/TypedArrayHistogram.spec.ts
+++ b/src/TypedArrayHistogram.spec.ts
@@ -69,7 +69,6 @@ import { decodeFromCompressedBase64 } from "./encoding";
   }
 );
 
-
 describe("Histogram bucket size overflow", () => {
   [Int8Histogram, Int16Histogram].forEach(
     (Histogram) => {
@@ -99,26 +98,17 @@ describe("Histogram bucket size overflow", () => {
         histogram2.recordValueWithCount(1, maxBucketSize);
         
         //when //then
-        try {
-          histogram1.add(histogram2);
-          fail(`should have failed due to ${bitBucketSize}bits integer overflow`);
-        } catch (e) {
-          //ok
-        }
+        expect(() => histogram1.add(histogram2)).toThrow();
       });
     });
     it("should fail when decoding an Int32 histogram with one bucket couunt greater than 16bits", () => {
       //given
       const int32Histogram = new Int32Histogram(1, Number.MAX_SAFE_INTEGER, 3);
       int32Histogram.recordValueWithCount(1, 2**32 - 1);
+      const encodedInt32Histogram = int32Histogram.encodeIntoCompressedBase64();
       
       //when //then
-      try {
-        const encodedInt32Histogram = int32Histogram.encodeIntoCompressedBase64();
-        decodeFromCompressedBase64(encodedInt32Histogram, 16);
-        fail(`should have failed due to bits integer overflow`);
-      } catch (e) {
-        //ok
-      }
+      expect(() => decodeFromCompressedBase64(encodedInt32Histogram, 16)).toThrow();
+
     });
 });

--- a/src/TypedArrayHistogram.ts
+++ b/src/TypedArrayHistogram.ts
@@ -52,18 +52,15 @@ class TypedArrayHistogram extends JsHistogram {
   addToCountAtIndex(index: number, value: number) {
     const currentCount = this._counts[index];
     const newCount = currentCount + value;
-    if (
-      newCount < Number.MIN_SAFE_INTEGER ||
-      newCount > Number.MAX_SAFE_INTEGER
-    ) {
-      throw newCount + " would overflow integer count";
+    if (newCount > this.maxBucketSize) {
+      throw newCount + " would overflow " + this._counts.BYTES_PER_ELEMENT * 8 + "bits integer count";
     }
     this._counts[index] = newCount;
   }
 
   setCountAtIndex(index: number, value: number) {
-    if (value < Number.MIN_SAFE_INTEGER || value > Number.MAX_SAFE_INTEGER) {
-      throw value + " would overflow integer count";
+    if (value > this.maxBucketSize) {
+      throw value + " would overflow " + this._counts.BYTES_PER_ELEMENT * 8 + "bits integer count";
     }
     this._counts[index] = value;
   }

--- a/src/TypedArrayHistogram.ts
+++ b/src/TypedArrayHistogram.ts
@@ -18,6 +18,8 @@ class TypedArrayHistogram extends JsHistogram {
   _counts: TypedArray;
   _totalCount: number;
 
+  maxBucketSize: number;
+
   constructor(
     private arrayCtr: new (size: number) => TypedArray,
     lowestDiscernibleValue: number,
@@ -31,6 +33,7 @@ class TypedArrayHistogram extends JsHistogram {
     );
     this._totalCount = 0;
     this._counts = new arrayCtr(this.countsArrayLength);
+    this.maxBucketSize = 2**(this._counts.BYTES_PER_ELEMENT * 8) - 1;
   }
 
   clearCounts() {
@@ -40,8 +43,8 @@ class TypedArrayHistogram extends JsHistogram {
   incrementCountAtIndex(index: number) {
     const currentCount = this._counts[index];
     const newCount = currentCount + 1;
-    if (newCount < 0) {
-      throw newCount + " would overflow short integer count";
+    if (newCount > this.maxBucketSize) {
+      throw newCount + " would overflow " + this._counts.BYTES_PER_ELEMENT * 8 + "bits integer count";
     }
     this._counts[index] = newCount;
   }


### PR DESCRIPTION
Hey,

This PR fixes an integer overflow issue in both AssemblyScript & Typescript implementations.

In short : on an `unsigned integer`, when overflow occurs, the value won't be read as a negative integer.

Please note that in the current implementation, the user could create an Histogram with a signed internal bucket of type `IntXArray` ; an issue will also occurs and this PR doesn't fix that case. :)

Note also that I didn't find a way to test the assembly version in assembly folder : the tested method throws, and it seems that try / catch aren't [supported yet](https://github.com/AssemblyScript/assemblyscript/issues/302)