### PR TITLE
Use SPDX License Name

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "url": "git+https://github.com/HdrHistogram/HdrHistogramJS.git"
   },
   "author": "Alexandre Victoor",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "devDependencies": {
     "@as-pect/cli": "^6.2.4",
     "@babel/preset-env": "^7.14.8",


### PR DESCRIPTION
You use according to your github repo BSD-2-Clause but unfortunately you use only BSD in the package.json. So our license check fails. This PR replaces BSD with the correct SPDX name.

https://github.com/fastify/fastify-hotwire/pull/77#issuecomment-1202801214
