### PR TITLE
perf: drop base64-js dependency, smaller bundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "hdr-histogram-js",
       "version": "4.0.0",
       "license": "BSD-2-Clause",
-      "dependencies": {
-        "base64-js": "^1.2.0"
-      },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^28.0.3",
         "@rollup/plugin-node-resolve": "^16.0.1",
@@ -2785,26 +2782,6 @@
       "engines": {
         "node": "18 || 20 || >=22"
       }
-    },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.18",

--- a/package.json
+++ b/package.json
@@ -60,9 +60,6 @@
     "vitest": "^4.1.4",
     "yargs": "^18.0.0"
   },
-  "dependencies": {
-    "base64-js": "^1.2.0"
-  },
   "files": [
     ".",
     "dist"

--- a/src/JsHistogram.encoding.ts
+++ b/src/JsHistogram.encoding.ts
@@ -5,8 +5,7 @@
  * and released to the public domain, as explained at
  * http://creativecommons.org/publicdomain/zero/1.0/
  */
-// @ts-ignore
-import * as base64 from "base64-js";
+import * as base64 from "./base64";
 import { JsHistogram } from "./JsHistogram";
 import ByteBuffer from "./ByteBuffer";
 import { BitBucketSize } from "./Histogram";

--- a/src/base64.ts
+++ b/src/base64.ts
@@ -1,0 +1,32 @@
+/*
+ * Minimal base64 codec replacing the `base64-js` dependency.
+ *
+ * Relies on the standard `btoa`/`atob` globals, available in Node >= 16 (this
+ * project requires >= 22) and all modern browsers. Produces and consumes
+ * standard base64 (`+`/`/`), matching what HdrHistogram encodes.
+ */
+
+// Uint8Array -> standard base64 string.
+// Build the binary string in chunks so large inputs (e.g. the WASM blob) don't
+// overflow String.fromCharCode's argument-stack limit.
+export function fromByteArray(bytes: Uint8Array): string {
+  const CHUNK = 0x8000;
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode.apply(
+      null,
+      bytes.subarray(i, i + CHUNK) as unknown as number[]
+    );
+  }
+  return btoa(binary);
+}
+
+// standard base64 string -> Uint8Array.
+export function toByteArray(b64: string): Uint8Array {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -10,8 +10,7 @@ import ByteBuffer from "./ByteBuffer";
 import Histogram from "./Histogram";
 import { WasmHistogram } from "./wasm";
 
-// @ts-ignore
-import * as base64 from "base64-js";
+import * as base64 from "./base64";
 import { inflate, deflate } from "./JsHistogram.encoding";
 
 const V2CompressedEncodingCookieBase = 0x1c849304;

--- a/src/wasm/index.ts
+++ b/src/wasm/index.ts
@@ -5,8 +5,7 @@ import Histogram, {
   toSummary,
   HistogramSummary
 } from "../Histogram";
-// @ts-ignore
-import * as base64 from "base64-js";
+import * as base64 from "../base64";
 import { inflate } from "../JsHistogram.encoding";
 import { BuildRequest } from "../HistogramBuilder";
 


### PR DESCRIPTION
Replace the `base64-js` npm package with a tiny dependency-free codec (src/base64.ts) built on the standard `btoa`/`atob` globals, available in Node >= 16 (this project requires >= 22) and all modern browsers. The wire format is unchanged (standard base64), so encoded histograms stay interoperable.

This removes HdrHistogramJS's last runtime dependency — the package now has zero production dependencies. Companion to the earlier pako removal.